### PR TITLE
Make 'object-curly-newline' rule 'consistent'

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,5 +53,6 @@ module.exports = {
     'no-mixed-operators': 0,
     'no-continue': 0,
     'react/forbid-prop-types': 0,
+    'object-curly-newline': ["error", { "consistent": true }],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cardash-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously, it would show the following lines as errors:
```
// Reported as an error
import {
  Foo,
} from './something'

// This is an error because there's more than 4 elements in the obj
<A style={{ height: 100, width: 200, zIndex: 1, top: 3, }} />
```
This commit relaxes the rule so that the above syntax is valid