### PR TITLE
[rules] disables import/extensions rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,5 +54,6 @@ module.exports = {
     'no-continue': 0,
     'react/forbid-prop-types': 0,
     'object-curly-newline': ["error", { "consistent": true }],
+    'import/extensions': 0,
   }
 }


### PR DESCRIPTION
because its throwing errors with webpack config