### PR TITLE
Turn off react/jsx-one-expression-per-line rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ module.exports = {
     'object-curly-newline': ["error", { "consistent": true }],
     'import/extensions': 0,
     'react/no-did-mount-set-state': 1,
-    'react/no-did-update-set-state': 1
+    'react/no-did-update-set-state': 1,
+    'react/jsx-one-expression-per-line': 0,
   }
 }


### PR DESCRIPTION
Right now, it's making code harder to read.

See: https://github.com/yannickcr/eslint-plugin-react/issues/1848